### PR TITLE
UI updates

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -309,16 +309,23 @@ The timetable GUI is created with the help of the https://github.com/dlemmermann
 
 A `TimetablePanel` is created with its constructor:
 ----
-TimetablePanel(ObservableList<Shift> shiftObservableList)`
+TimetablePanel(ObservableList<Shift> shiftObservableList, OutletInformation outletInformation)
 ----
 
 The `TimetablePanel` is initialised in the `MainWindow` class in the following way:
 ----
-TimetablePanel timetablePanel = new TimetablePanel(logic.getFilteredShiftList());
+TimetablePanel timetablePanel = new TimetablePanel(logic.getFilteredShiftList(), logic.getOutletInformation());
 ----
 
-`TimetablePanel` takes in an `ObservableList<Shift>` object, which is an unmodifiable sorted view of the filtered shifts.
- `TimetablePanel` then uses these `Shift` objects to set the Entries in the timetable view, in the method `setShifts()`.+
+`TimetablePanel` takes in:
+
+ * An `ObservableList<Shift>` object, which is an unmodifiable sorted view of the filtered shifts.
+ * An `OutletInformation` object, which contains information of the outlet that is required to build the timetable.
+  In particular, the operating hours of the outlet.
+
+`TimetablePanel` then uses these `Shift` objects to set the Entries in the timetable view, in the method `setShifts()`.
+The operating hours acquired from `OutletInformation` is then used in `updateTimetableView()` to ensure that the timetable
+displays all the time slots within this time range. +
 
 The timetable GUI automatically refreshes to update the timetable view by calling the `updateTimetableView()` method whenever
 there is a `PartTimeManagerChangedEvent`. This ensures the timetable is always updated when a shift is added, removed, or altered.

--- a/src/main/java/seedu/ptman/commons/events/ui/OutletInformationChangedEvent.java
+++ b/src/main/java/seedu/ptman/commons/events/ui/OutletInformationChangedEvent.java
@@ -7,10 +7,14 @@ import seedu.ptman.commons.events.BaseEvent;
  */
 public class OutletInformationChangedEvent extends BaseEvent {
 
-    public final String information;
+    public final String operatingHours;
+    public final String outletContact;
+    public final String outletEmail;
 
-    public OutletInformationChangedEvent(String information) {
-        this.information = information;
+    public OutletInformationChangedEvent(String operatingHours, String outletContact, String outletEmail) {
+        this.operatingHours = operatingHours;
+        this.outletContact = outletContact;
+        this.outletEmail = outletEmail;
     }
 
     @Override

--- a/src/main/java/seedu/ptman/logic/commands/EditOutletCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/EditOutletCommand.java
@@ -67,7 +67,10 @@ public class EditOutletCommand extends UndoableCommand {
             OutletInformation editedOutlet = new OutletInformation(model.getOutletInformation());
             editedOutlet.setOutletInformation(name, operatingHours, outletContact, outletEmail);
             model.updateOutlet(editedOutlet);
-            EventsCenter.getInstance().post(new OutletInformationChangedEvent(editedOutlet.toString()));
+            EventsCenter.getInstance().post(new OutletInformationChangedEvent(
+                    editedOutlet.getOperatingHours().toString(),
+                    editedOutlet.getOutletContact().toString(),
+                    editedOutlet.getOutletEmail().toString()));
             EventsCenter.getInstance().post(new OutletNameChangedEvent(editedOutlet.getName().toString()));
         } catch (NoOutletInformationFieldChangeException e) {
             throw new CommandException(MESSAGE_EDIT_OUTLET_FAILURE);

--- a/src/main/java/seedu/ptman/logic/commands/UndoableCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/UndoableCommand.java
@@ -45,7 +45,8 @@ public abstract class UndoableCommand extends Command {
         model.resetData(previousPartTimeManager);
         model.updateFilteredEmployeeList(PREDICATE_SHOW_ALL_EMPLOYEES);
         OutletInformation previousOutlet = previousPartTimeManager.getOutletInformation();
-        EventsCenter.getInstance().post(new OutletInformationChangedEvent(previousOutlet.toString()));
+        EventsCenter.getInstance().post(new OutletInformationChangedEvent(previousOutlet.getOperatingHours().toString(),
+                previousOutlet.getOutletContact().toString(), previousOutlet.getOutletEmail().toString()));
         EventsCenter.getInstance().post(new OutletNameChangedEvent(previousOutlet.getName().toString()));
         EventsCenter.getInstance().post(new AnnouncementChangedEvent(previousOutlet.getAnnouncement().toString()));
     }

--- a/src/main/java/seedu/ptman/model/outlet/OutletInformation.java
+++ b/src/main/java/seedu/ptman/model/outlet/OutletInformation.java
@@ -165,7 +165,7 @@ public class OutletInformation {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append("Operating Hour: ")
+        builder.append("Operating Hours: ")
                 .append(getOperatingHours())
                 .append(" Contact: ")
                 .append(getOutletContact())

--- a/src/main/java/seedu/ptman/ui/CommandBox.java
+++ b/src/main/java/seedu/ptman/ui/CommandBox.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.ptman.commons.core.LogsCenter;
@@ -26,6 +27,7 @@ public class CommandBox extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(CommandBox.class);
     private final Logic logic;
     private ListElementPointer historySnapshot;
+    private final Tooltip tooltip = new Tooltip();
 
     @FXML
     private TextField commandTextField;
@@ -36,6 +38,8 @@ public class CommandBox extends UiPart<Region> {
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
         historySnapshot = logic.getHistorySnapshot();
+        tooltip.setText("Tip: Enter \"help\" when you get stuck");
+        commandTextField.setTooltip(tooltip);
     }
 
     /**

--- a/src/main/java/seedu/ptman/ui/MainWindow.java
+++ b/src/main/java/seedu/ptman/ui/MainWindow.java
@@ -126,7 +126,7 @@ public class MainWindow extends UiPart<Stage> {
         outletPanel = new OutletDetailsPanel(logic.getOutletInformation());
         outletDetailsPanelPlaceholder.getChildren().add(outletPanel.getRoot());
 
-        timetablePanel = new TimetablePanel(logic.getFilteredShiftList());
+        timetablePanel = new TimetablePanel(logic.getFilteredShiftList(), logic.getOutletInformation());
         timetableViewPlaceholder.getChildren().add(timetablePanel.getRoot());
 
         employeeListPanel = new EmployeeListPanel(logic.getFilteredEmployeeList());

--- a/src/main/java/seedu/ptman/ui/OutletDetailsPanel.java
+++ b/src/main/java/seedu/ptman/ui/OutletDetailsPanel.java
@@ -29,7 +29,13 @@ public class OutletDetailsPanel extends UiPart<Region> {
     private Label outletNamePanelHeader;
 
     @FXML
-    private Label outletInformation;
+    private Label operatingHours;
+
+    @FXML
+    private Label outletContact;
+
+    @FXML
+    private Label outletEmail;
 
     @FXML
     private Label announcement;
@@ -38,8 +44,10 @@ public class OutletDetailsPanel extends UiPart<Region> {
     public OutletDetailsPanel(OutletInformation outlet) {
         super(FXML);
         this.outlet = outlet;
-        outletInformation.setWrapText(true);
-        setOutletInformation(outlet.toString());
+        //outletInformation.setWrapText(true);
+        setOutletInformation(outlet.getOperatingHours().toString(),
+                outlet.getOutletContact().toString(),
+                outlet.getOutletEmail().toString());
         setOutletName(outlet.getName().toString());
         setAnnouncement(outlet.getAnnouncement().toString());
 
@@ -50,8 +58,10 @@ public class OutletDetailsPanel extends UiPart<Region> {
         outletNamePanelHeader.setText(name);
     }
 
-    private void setOutletInformation(String information) {
-        outletInformation.setText(information);
+    private void setOutletInformation(String operatingHours, String outletContact, String outletEmail) {
+        this.operatingHours.setText(operatingHours + "    ");
+        this.outletContact.setText(outletContact + "    ");
+        this.outletEmail.setText(outletEmail);
     }
 
     private void setAnnouncement(String text) {
@@ -61,7 +71,7 @@ public class OutletDetailsPanel extends UiPart<Region> {
     @Subscribe
     private void handleOutletInformationChangedEvent(OutletInformationChangedEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
-        Platform.runLater(() -> setOutletInformation(event.information));
+        Platform.runLater(() -> setOutletInformation(event.operatingHours, event.outletContact, event.outletEmail));
     }
 
     @Subscribe

--- a/src/main/java/seedu/ptman/ui/TimetablePanel.java
+++ b/src/main/java/seedu/ptman/ui/TimetablePanel.java
@@ -3,8 +3,8 @@ package seedu.ptman.ui;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.temporal.WeekFields;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.WeekFields;
 import java.util.Locale;
 import java.util.logging.Logger;
 
@@ -28,7 +28,7 @@ import seedu.ptman.model.outlet.OutletInformation;
 import seedu.ptman.model.outlet.Shift;
 import seedu.ptman.model.outlet.Timetable;
 
-
+//@@author hzxcaryn
 /**
  * Displays the GUI Timetable.
  */
@@ -125,7 +125,8 @@ public class TimetablePanel extends UiPart<Region> {
             LocalDate date = getDateOfShift(shift.getDay().toDayOfWeek());
             Interval timeInterval = new Interval(date, shift.getStartTime().getLocalTime(),
                     date, shift.getEndTime().getLocalTime());
-            Entry<String> shiftEntry = new Entry<>("SHIFT " + index + "\nSlots left: " + shift.getSlotsLeft(), timeInterval);
+            Entry<String> shiftEntry = new Entry<>("SHIFT " + index + "\nSlots left: " + shift.getSlotsLeft(),
+                    timeInterval);
             Calendar entryType = getEntryType(shift);
             entryType.addEntry(shiftEntry);
             index++;

--- a/src/main/java/seedu/ptman/ui/TimetablePanel.java
+++ b/src/main/java/seedu/ptman/ui/TimetablePanel.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.WeekFields;
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 import java.util.logging.Logger;
 
@@ -12,6 +13,8 @@ import com.calendarfx.model.CalendarSource;
 import com.calendarfx.model.Entry;
 import com.calendarfx.model.Interval;
 import com.calendarfx.view.CalendarView;
+import com.calendarfx.view.DayViewBase;
+import com.calendarfx.view.DetailedWeekView;
 
 import com.google.common.eventbus.Subscribe;
 
@@ -21,6 +24,7 @@ import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
 import seedu.ptman.commons.core.LogsCenter;
 import seedu.ptman.commons.events.model.PartTimeManagerChangedEvent;
+import seedu.ptman.model.outlet.OutletInformation;
 import seedu.ptman.model.outlet.Shift;
 import seedu.ptman.model.outlet.Timetable;
 
@@ -40,21 +44,23 @@ public class TimetablePanel extends UiPart<Region> {
 
     private Timetable timetable;
     private ObservableList<Shift> shiftObservableList;
+    private OutletInformation outletInformation;
 
     private Calendar timetableAvail;
     private Calendar timetableRunningOut;
     private Calendar timetableFull;
 
-    public TimetablePanel(ObservableList<Shift> shiftObservableList) {
+    protected TimetablePanel(ObservableList<Shift> shiftObservableList, OutletInformation outletInformation) {
         super(FXML);
 
         timetable = new Timetable(LocalDate.now());
-
         this.shiftObservableList = shiftObservableList;
+        this.outletInformation = outletInformation;
 
         timetableView = new CalendarView();
-
         showRelevantViewsOnly();
+        // disable clicks on timetable view
+        timetableView.getWeekPage().setMouseTransparent(true);
 
         updateTimetableView();
 
@@ -66,14 +72,15 @@ public class TimetablePanel extends UiPart<Region> {
     }
 
     /**
-     * Only show the parts of CalendarFX that we need
+     * Only show the parts of CalendarFX that we need.
      */
     private void showRelevantViewsOnly() {
         timetableView.showWeekPage();
 
+        timetableView.getWeekPage().setShowNavigation(false);
+        timetableView.getWeekPage().setShowDate(false);
         timetableView.weekFieldsProperty().setValue(WeekFields.of(Locale.FRANCE)); // Start week from Monday
-        timetableView.disableProperty();
-        timetableView.setShowToday(false);
+        timetableView.setShowToday(true);
         timetableView.setShowPrintButton(true);
         timetableView.setShowAddCalendarButton(false);
         timetableView.setShowSearchField(false);
@@ -83,25 +90,45 @@ public class TimetablePanel extends UiPart<Region> {
         timetableView.setShowSearchResultsTray(false);
         timetableView.setShowSourceTray(false);
         timetableView.setShowSourceTrayButton(false);
-    }
-
-    private void setTime() {
-        timetableView.setToday(LocalDate.now());
-        timetableView.setTime(LocalTime.now());
+        timetableView.getWeekPage().getDetailedWeekView().setShowAllDayView(false);
     }
 
     /**
-     * Takes default outlet shifts and set timetable entries based on these shifts
+     * This ensures that the range of the times shown by the timetable view is constrained to the
+     * operating hours of the outlet.
+     * Also ensures that no scrolling is required to view the entire timetable.
+     */
+    private void setTimetableRange() {
+        LocalTime startTime = outletInformation.getOperatingHours().getStartTime();
+        LocalTime endTime = outletInformation.getOperatingHours().getEndTime();
+        timetableView.setStartTime(startTime);
+        timetableView.setEndTime(endTime);
+
+        DetailedWeekView detailedWeekView = timetableView.getWeekPage().getDetailedWeekView();
+        detailedWeekView.setEarlyLateHoursStrategy(DayViewBase.EarlyLateHoursStrategy.HIDE);
+        detailedWeekView.setHoursLayoutStrategy(DayViewBase.HoursLayoutStrategy.FIXED_HOUR_COUNT);
+        detailedWeekView.setVisibleHours(Math.max((int) ChronoUnit.HOURS.between(startTime, endTime), 12));
+        detailedWeekView.setShowScrollBar(false);
+        detailedWeekView.setEnableCurrentTimeMarker(false);
+    }
+
+    private void setCurrentTime() {
+        timetableView.setToday(LocalDate.now());
+    }
+
+    /**
+     * Takes default outlet shifts and set timetable entries based on these shifts.
      */
     private void setShifts() {
+        int index = 1;
         for (Shift shift: shiftObservableList) {
-            // TODO: Add Time Slot index to each Shift
             LocalDate date = getDateOfShift(shift.getDay().toDayOfWeek());
             Interval timeInterval = new Interval(date, shift.getStartTime().getLocalTime(),
                     date, shift.getEndTime().getLocalTime());
-            Entry<String> shiftEntry = new Entry<>("Slots left: " + shift.getSlotsLeft(), timeInterval);
+            Entry<String> shiftEntry = new Entry<>("Slot " + index + "\nSlots left: " + shift.getSlotsLeft(), timeInterval);
             Calendar entryType = getEntryType(shift);
             entryType.addEntry(shiftEntry);
+            index++;
         }
     }
 
@@ -130,16 +157,18 @@ public class TimetablePanel extends UiPart<Region> {
     }
 
     /**
-     * Replaces timetableView with a new timetable with updated shift information
+     * Replaces timetableView with a new timetable with updated shift and outlet information
      */
     private void updateTimetableView() {
-        setTime();
+        setCurrentTime();
         timetableView.getCalendarSources().clear();
         CalendarSource calendarSource = new CalendarSource("Shifts");
         addCalendars(calendarSource);
 
         setShifts();
         timetableView.getCalendarSources().add(calendarSource);
+
+        setTimetableRange();
     }
 
     /**

--- a/src/main/java/seedu/ptman/ui/TimetablePanel.java
+++ b/src/main/java/seedu/ptman/ui/TimetablePanel.java
@@ -125,7 +125,7 @@ public class TimetablePanel extends UiPart<Region> {
             LocalDate date = getDateOfShift(shift.getDay().toDayOfWeek());
             Interval timeInterval = new Interval(date, shift.getStartTime().getLocalTime(),
                     date, shift.getEndTime().getLocalTime());
-            Entry<String> shiftEntry = new Entry<>("Slot " + index + "\nSlots left: " + shift.getSlotsLeft(), timeInterval);
+            Entry<String> shiftEntry = new Entry<>("SHIFT " + index + "\nSlots left: " + shift.getSlotsLeft(), timeInterval);
             Calendar entryType = getEntryType(shift);
             entryType.addEntry(shiftEntry);
             index++;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -168,24 +168,16 @@
      -fx-border-top-width: 1px;
 }
 
-.outlet-information .content {
-    -fx-background-color: derive(#1d1d1d, 20%);
-}
-
 .outlet-information {
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 14px;
     -fx-text-fill: white;
 }
 
-.announcement .content {
-    -fx-background-color: derive(#1d1d1d, 20%);
-}
-
 .announcement {
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 14px;
-    -fx-text-fill: yellow;
+    -fx-text-fill: white;
 }
 
 .status-bar {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.3" VBox.vgrow="ALWAYS">
-          <VBox minWidth="400">
+          <VBox>
             <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-dark-background"
                        minHeight="100" prefHeight="100" maxHeight="100">
               <padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.3" VBox.vgrow="ALWAYS">
-          <VBox>
+          <VBox minWidth="650">
             <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-dark-background"
                        minHeight="100" prefHeight="100" maxHeight="100">
               <padding>
@@ -61,7 +61,7 @@
             </StackPane>
           </VBox>
 
-          <VBox fx:id="employeeList" minWidth="340" prefWidth="340" SplitPane.resizableWithParent="false">
+          <VBox fx:id="employeeList" minWidth="300" SplitPane.resizableWithParent="false">
             <StackPane fx:id="employeeListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -40,7 +40,7 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.3" VBox.vgrow="ALWAYS">
-          <VBox minWidth="650">
+          <VBox minWidth="400">
             <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-dark-background"
                        minHeight="100" prefHeight="100" maxHeight="100">
               <padding>

--- a/src/main/resources/view/OutletDetailsPanel.fxml
+++ b/src/main/resources/view/OutletDetailsPanel.fxml
@@ -5,15 +5,13 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane xmlns:fx="http://javafx.com/fxml/1">
+<StackPane xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8.0.121">
     <VBox>
-        <Label fx:id="outletNamePanelHeader" styleClass="panel_large_label"/>
+        <Label fx:id="outletNamePanelHeader" styleClass="panel_large_label" />
+        <Label fx:id="outletInformation" styleClass="outlet-information" />
+
         <padding>
-            <Insets top="20" right="15" bottom="15" left="15" />
+            <Insets bottom="15" left="15" right="15" top="20" />
         </padding>
-        <StackPane fx:id="placeHolder" xmlns="http://javafx.com/javafx/8"
-                   xmlns:fx="http://javafx.com/fxml/1">
-            <Label fx:id="outletInformation" styleClass="outlet-information"/>
-        </StackPane>
     </VBox>
 </StackPane>

--- a/src/main/resources/view/OutletDetailsPanel.fxml
+++ b/src/main/resources/view/OutletDetailsPanel.fxml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8.0.121">
+<StackPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1">
     <VBox>
         <Label fx:id="outletNamePanelHeader" styleClass="panel_large_label" />
-        <Label fx:id="outletInformation" styleClass="outlet-information" />
-        <Label fx:id="announcement" styleClass="announcement"/>
+        <HBox fx:id="outletInformation">
+            <Label fx:id="operatingHours" styleClass="outlet-information">><graphic><FontAwesomeIconView fill="WHITE" glyphName="CALENDAR" /></graphic></Label>
+            <Label fx:id="outletContact" styleClass="outlet-information">><graphic><FontAwesomeIconView fill="WHITE" glyphName="PHONE" /></graphic></Label>
+            <Label fx:id="outletEmail" styleClass="outlet-information">><graphic><FontAwesomeIconView fill="WHITE" glyphName="ENVELOPE" /></graphic></Label>
+        </HBox>
+        <Label fx:id="announcement" styleClass="announcement"><graphic><FontAwesomeIconView fill="WHITE" glyphName="BULLHORN" /></graphic></Label>
         <padding>
             <Insets bottom="15" left="15" right="15" top="20" />
         </padding>

--- a/src/test/java/guitests/guihandles/OutletDetailsPanelHandle.java
+++ b/src/test/java/guitests/guihandles/OutletDetailsPanelHandle.java
@@ -27,6 +27,7 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
     private String lastRememberedOutletOperatingHours;
     private String lastRememberedOutletContact;
     private String lastRememberedOutletEmail;
+    private String lastRememberedOutletAnnouncement;
 
     public OutletDetailsPanelHandle(Node outletDetailsNode) {
         super(outletDetailsNode);
@@ -106,6 +107,21 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
         boolean isOutletContactChanged = !lastRememberedOutletContact.equals(getOutletContact());
         boolean isOutletEmailChanged = !lastRememberedOutletEmail.equals(getOutletContact());
         return isOutletOperatingHoursChanged && isOutletContactChanged && isOutletEmailChanged;
+    }
+
+    /**
+     * Remembers the outlet name in the outlet panel.
+     */
+    public void rememberOutletAnnouncement() {
+        lastRememberedOutletAnnouncement = getAnnouncement();
+    }
+
+    /**
+     * Returns true if the current outlet name is different from the value remembered by the most recent
+     * {@code rememberOutletName()} call.
+     */
+    public boolean isOutletAnnouncementChanged() {
+        return !lastRememberedOutletAnnouncement.equals(getAnnouncement());
     }
 
 }

--- a/src/test/java/guitests/guihandles/OutletDetailsPanelHandle.java
+++ b/src/test/java/guitests/guihandles/OutletDetailsPanelHandle.java
@@ -12,21 +12,29 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
     public static final String OUTLET_ID = "#outletDetailsPanelPlaceholder";
 
     private static final String OUTLET_NAME_ID = "#outletNamePanelHeader";
-    private static final String OUTLET_INFORMATION_ID = "#outletInformation";
+    private static final String OUTLET_OPERATING_HOURS_ID = "#operatingHours";
+    private static final String OUTLET_CONTACT_ID = "#outletContact";
+    private static final String OUTLET_EMAIL_ID = "#outletEmail";
     private static final String OUTLET_ANNOUNCEMENT_ID = "#announcement";
 
     private final Label outletNameNode;
-    private final Label outletInformationNode;
+    private final Label outletOperatingHoursNode;
+    private final Label outletContactNode;
+    private final Label outletEmailNode;
     private final Label outletAnnouncementNode;
 
     private String lastRememberedOutletName;
-    private String lastRememberedOutletInformation;
+    private String lastRememberedOutletOperatingHours;
+    private String lastRememberedOutletContact;
+    private String lastRememberedOutletEmail;
 
     public OutletDetailsPanelHandle(Node outletDetailsNode) {
         super(outletDetailsNode);
 
         this.outletNameNode = getChildNode(OUTLET_NAME_ID);
-        this.outletInformationNode = getChildNode(OUTLET_INFORMATION_ID);
+        this.outletOperatingHoursNode = getChildNode(OUTLET_OPERATING_HOURS_ID);
+        this.outletContactNode = getChildNode(OUTLET_CONTACT_ID);
+        this.outletEmailNode = getChildNode(OUTLET_EMAIL_ID);
         this.outletAnnouncementNode = getChildNode(OUTLET_ANNOUNCEMENT_ID);
     }
 
@@ -47,8 +55,22 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
     /**
      * @return the outlet info in outlet panel.
      */
-    public String getOutletInformation() {
-        return outletInformationNode.getText();
+    public String getOutletOperatingHours() {
+        return outletOperatingHoursNode.getText();
+    }
+
+    /**
+     * @return the outlet info in outlet panel.
+     */
+    public String getOutletContact() {
+        return outletContactNode.getText();
+    }
+
+    /**
+     * @return the outlet info in outlet panel.
+     */
+    public String getOutletEmail() {
+        return outletEmailNode.getText();
     }
 
     /**
@@ -70,7 +92,9 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
      * Remembers the outlet info in the outlet panel.
      */
     public void rememberOutletInformation() {
-        lastRememberedOutletInformation = getOutletInformation();
+        lastRememberedOutletOperatingHours = getOutletOperatingHours();
+        lastRememberedOutletContact = getOutletContact();
+        lastRememberedOutletEmail = getOutletEmail();
     }
 
     /**
@@ -78,7 +102,10 @@ public class OutletDetailsPanelHandle extends NodeHandle<Node> {
      * recent {@code rememberOutletInformation()} call.
      */
     public boolean isOutletInformationChanged() {
-        return !lastRememberedOutletInformation.equals(getOutletInformation());
+        boolean isOutletOperatingHoursChanged = !lastRememberedOutletOperatingHours.equals(getOutletOperatingHours());
+        boolean isOutletContactChanged = !lastRememberedOutletContact.equals(getOutletContact());
+        boolean isOutletEmailChanged = !lastRememberedOutletEmail.equals(getOutletContact());
+        return isOutletOperatingHoursChanged && isOutletContactChanged && isOutletEmailChanged;
     }
 
 }

--- a/src/test/java/seedu/ptman/model/outlet/OutletInformationTest.java
+++ b/src/test/java/seedu/ptman/model/outlet/OutletInformationTest.java
@@ -126,7 +126,7 @@ public class OutletInformationTest {
         Announcement announcement = new Announcement("New Announcement.");
         OutletInformation outlet = new OutletInformation(name, operatingHours, outletContact, outletEmail,
                 password, announcement);
-        String expected = "Operating Hour: 09:00-22:00 Contact: 91234567 "
+        String expected = "Operating Hours: 09:00-22:00 Contact: 91234567 "
                 + "Email: outlet@gmail.com";
         assertEquals(outlet.toString(), expected);
     }

--- a/src/test/java/seedu/ptman/ui/OutletDetailsPanelTest.java
+++ b/src/test/java/seedu/ptman/ui/OutletDetailsPanelTest.java
@@ -24,7 +24,8 @@ public class OutletDetailsPanelTest extends GuiUnitTest {
 
     @Before
     public void setUp() {
-        outletInformationChangedEventStub = new OutletInformationChangedEvent("New Outlet Information");
+        outletInformationChangedEventStub = new OutletInformationChangedEvent("New Operating Hours",
+                "New Outlet Contact", "New Outlet Email");
         outletNameChangedEventStub = new OutletNameChangedEvent("New Outlet Name");
         announcementChangedEventStub = new AnnouncementChangedEvent("New Announcement");
         outletDetailsPanel = new OutletDetailsPanel(outlet);
@@ -37,15 +38,29 @@ public class OutletDetailsPanelTest extends GuiUnitTest {
     public void display() {
         // Default outlet name and information
         String expectedDefaultOutletName = "DefaultOutlet";
-        String expectedDefaultOutletInformation = "Operating Hour: 09:00-22:00 Contact: 91234567 "
-                + "Email: DefaultOutlet@gmail.com";
-        assertEquals(expectedDefaultOutletInformation, outletDetailsPanelHandle.getOutletInformation());
+        String expectedTrimmedDefaultOutletOperatingHours = "09:00-22:00";
+        String expectedTrimmedDefaultOutletContact = "91234567";
+        String expectedTrimmedDefaultOutletEmail = "DefaultOutlet@gmail.com";
+        assertEquals(expectedTrimmedDefaultOutletOperatingHours,
+                outletDetailsPanelHandle.getOutletOperatingHours().trim());
+        assertEquals(expectedTrimmedDefaultOutletContact, outletDetailsPanelHandle.getOutletContact().trim());
+        assertEquals(expectedTrimmedDefaultOutletEmail, outletDetailsPanelHandle.getOutletEmail().trim());
         assertEquals(expectedDefaultOutletName, outletDetailsPanelHandle.getOutletName());
 
-        // Outlet Information Updated
+        // Outlet Information: Operating Hours Updated
         postNow(outletInformationChangedEventStub);
-        String expectedOutletInformation = "New Outlet Information";
-        assertEquals(expectedOutletInformation, outletDetailsPanelHandle.getOutletInformation());
+        String expectedTrimmedOutletOperatingHours = "New Operating Hours";
+        assertEquals(expectedTrimmedOutletOperatingHours, outletDetailsPanelHandle.getOutletOperatingHours().trim());
+
+        // Outlet Information: Contact Updated
+        postNow(outletInformationChangedEventStub);
+        String expectedTrimmedOutletContact = "New Outlet Contact";
+        assertEquals(expectedTrimmedOutletContact, outletDetailsPanelHandle.getOutletContact().trim());
+
+        // Outlet Information: Email Updated
+        postNow(outletInformationChangedEventStub);
+        String expectedTrimmedOutletEmail = "New Outlet Email";
+        assertEquals(expectedTrimmedOutletEmail, outletDetailsPanelHandle.getOutletEmail().trim());
 
         // Outlet Name Updated
         postNow(outletNameChangedEventStub);

--- a/src/test/java/seedu/ptman/ui/TimetablePanelTest.java
+++ b/src/test/java/seedu/ptman/ui/TimetablePanelTest.java
@@ -15,7 +15,8 @@ public class TimetablePanelTest extends GuiUnitTest {
 
     @Before
     public void setUp() {
-        timetablePanel = new TimetablePanel(TypicalEmployees.getTypicalPartTimeManager().getShiftList());
+        timetablePanel = new TimetablePanel(TypicalEmployees.getTypicalPartTimeManager().getShiftList(),
+                TypicalEmployees.getTypicalPartTimeManager().getOutletInformation());
         uiPartRule.setUiPart(timetablePanel);
     }
 

--- a/src/test/java/systemtests/PartTimeManagerSystemTest.java
+++ b/src/test/java/systemtests/PartTimeManagerSystemTest.java
@@ -198,6 +198,7 @@ public abstract class PartTimeManagerSystemTest {
      */
     private void rememberStates() {
         OutletDetailsPanelHandle outletDetailsPanelHandle = getOutletDetailsPanel();
+        outletDetailsPanelHandle.rememberOutletAnnouncement();
         outletDetailsPanelHandle.rememberOutletInformation();
         outletDetailsPanelHandle.rememberOutletName();
         StatusBarFooterHandle statusBarFooterHandle = getStatusBarFooter();
@@ -264,6 +265,7 @@ public abstract class PartTimeManagerSystemTest {
      */
     protected void assertOutletDetailsPanelUnchanged() {
         OutletDetailsPanelHandle handle = getOutletDetailsPanel();
+        assertFalse(handle.isOutletAnnouncementChanged());
         assertFalse(handle.isOutletInformationChanged());
         assertFalse(handle.isOutletNameChanged());
     }


### PR DESCRIPTION
Changes:
- Shift index now visible
- No more irrelevant views in calendarFX
- No more mouse click actions for calendarFX 
- Start and End time of the timetable is taken from operating hours of the outlet, the rest of the timings are hidden from view
- Entire timetable is compacted into space given for timetable(previously timetable is scrollable). This is to prepare for _export timetable as image command_ where we will be using a snapshot of the timetable
- Adjusted panel proportions (employee panel gets less space)
- Edited outlet details format
- Added tooltip to command box for the lost souls