### PR TITLE
Create and implement the unapply command

### DIFF
--- a/src/main/java/seedu/ptman/logic/commands/UnapplyCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/UnapplyCommand.java
@@ -1,0 +1,123 @@
+package seedu.ptman.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.ptman.logic.parser.CliSyntax.PREFIX_PASSWORD;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.ptman.commons.core.Messages;
+import seedu.ptman.commons.core.index.Index;
+import seedu.ptman.logic.commands.exceptions.CommandException;
+import seedu.ptman.logic.commands.exceptions.MissingPasswordException;
+import seedu.ptman.model.Model;
+import seedu.ptman.model.Password;
+import seedu.ptman.model.employee.Employee;
+import seedu.ptman.model.employee.exceptions.EmployeeNotFoundException;
+import seedu.ptman.model.employee.exceptions.InvalidPasswordException;
+import seedu.ptman.model.outlet.Shift;
+import seedu.ptman.model.outlet.exceptions.DuplicateShiftException;
+import seedu.ptman.model.outlet.exceptions.ShiftNotFoundException;
+
+/**
+ * Registers an employee to a shift identified using their last displayed index from PTMan.
+ */
+public class UnapplyCommand extends UndoableCommand {
+
+    public static final String COMMAND_WORD = "unapply";
+    public static final String COMMAND_ALIAS = "uap";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Removes an employee from the shift identified by the index number.\n"
+            + "Parameters: EMPLOYEE_INDEX (must be a positive integer) "
+            + "SHIFT_INDEX "
+            + PREFIX_PASSWORD + "PASSWORD\n"
+            + "Example: " + COMMAND_WORD + " 1 1 " + PREFIX_PASSWORD + "hunter2";
+
+    public static final String MESSAGE_UNAPPLY_SHIFT_SUCCESS = "Employee %1$s removed from shift %2$s";
+    public static final String MESSAGE_EMPLOYEE_NOT_FOUND = "Employee is not in the shift.";
+
+    private final Index employeeIndex;
+    private final Index shiftIndex;
+    private final Optional<Password> optionalPassword;
+
+    private Employee applicant;
+    private Shift shiftToUnapply;
+    private Shift editedShift;
+
+    public UnapplyCommand(Index employeeIndex, Index shiftIndex, Optional<Password> optionalPassword) {
+        this.optionalPassword = optionalPassword;
+        this.employeeIndex = employeeIndex;
+        this.shiftIndex = shiftIndex;
+    }
+
+
+    @Override
+    public CommandResult executeUndoableCommand() throws CommandException {
+        requireNonNull(applicant);
+
+        if (!model.isAdminMode()) {
+            if (!optionalPassword.isPresent()) {
+                throw new MissingPasswordException();
+            }
+            if (!applicant.isCorrectPassword(optionalPassword.get())) {
+                throw new InvalidPasswordException();
+            }
+        }
+
+        try {
+            model.updateShift(shiftToUnapply, editedShift);
+        } catch (ShiftNotFoundException e) {
+            throw new AssertionError("Shift not found");
+        } catch (DuplicateShiftException e) {
+            throw new AssertionError("Duplicate shift");
+        }
+
+        model.updateFilteredShiftList(Model.PREDICATE_SHOW_ALL_SHIFTS);
+        return new CommandResult(String.format(MESSAGE_UNAPPLY_SHIFT_SUCCESS,
+                applicant.getName(), shiftIndex.getOneBased()));
+    }
+
+    @Override
+    protected void preprocessUndoableCommand() throws CommandException {
+        List<Employee> lastShownList = model.getFilteredEmployeeList();
+        List<Shift> shiftList = model.getFilteredShiftList();
+
+        if (employeeIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EMPLOYEE_DISPLAYED_INDEX);
+        }
+        if (shiftIndex.getZeroBased() >= shiftList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_SHIFT_DISPLAYED_INDEX);
+        }
+
+        applicant = lastShownList.get(employeeIndex.getZeroBased());
+        shiftToUnapply = shiftList.get(shiftIndex.getZeroBased());
+        editedShift = new Shift(shiftToUnapply);
+        try {
+            editedShift.removeEmployee(applicant);
+        } catch (EmployeeNotFoundException e) {
+            throw new CommandException(MESSAGE_EMPLOYEE_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UnapplyCommand that = (UnapplyCommand) o;
+        return Objects.equals(employeeIndex, that.employeeIndex)
+                && Objects.equals(shiftIndex, that.shiftIndex)
+                && Objects.equals(applicant, that.applicant)
+                && Objects.equals(shiftToUnapply, that.shiftToUnapply);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(employeeIndex, shiftIndex, applicant, shiftToUnapply);
+    }
+}

--- a/src/main/java/seedu/ptman/logic/commands/UnapplyCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/UnapplyCommand.java
@@ -118,6 +118,6 @@ public class UnapplyCommand extends UndoableCommand {
 
     @Override
     public int hashCode() {
-        return Objects.hash(employeeIndex, shiftIndex, applicant, shiftToUnapply);
+        return Objects.hash(employeeIndex, shiftIndex, applicant, shiftToUnapply, optionalPassword);
     }
 }

--- a/src/main/java/seedu/ptman/logic/commands/exceptions/MissingPasswordException.java
+++ b/src/main/java/seedu/ptman/logic/commands/exceptions/MissingPasswordException.java
@@ -1,0 +1,10 @@
+package seedu.ptman.logic.commands.exceptions;
+
+/**
+ * Signals that the operation will result in incorrect Password objects.
+ */
+public class MissingPasswordException extends CommandException {
+    public MissingPasswordException() {
+        super("Password not present");
+    }
+}

--- a/src/main/java/seedu/ptman/logic/parser/PartTimeManagerParser.java
+++ b/src/main/java/seedu/ptman/logic/parser/PartTimeManagerParser.java
@@ -33,6 +33,7 @@ import seedu.ptman.logic.commands.LogInAdminCommand;
 import seedu.ptman.logic.commands.LogOutAdminCommand;
 import seedu.ptman.logic.commands.RedoCommand;
 import seedu.ptman.logic.commands.SelectCommand;
+import seedu.ptman.logic.commands.UnapplyCommand;
 import seedu.ptman.logic.commands.UndoCommand;
 import seedu.ptman.logic.commands.ViewOutletCommand;
 import seedu.ptman.logic.parser.exceptions.ParseException;
@@ -73,6 +74,10 @@ public class PartTimeManagerParser {
         case ApplyCommand.COMMAND_WORD:
         case ApplyCommand.COMMAND_ALIAS:
             return new ApplyCommandParser().parse(arguments);
+
+        case UnapplyCommand.COMMAND_WORD:
+        case UnapplyCommand.COMMAND_ALIAS:
+            return new UnapplyCommandParser().parse(arguments);
 
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/ptman/logic/parser/UnapplyCommandParser.java
+++ b/src/main/java/seedu/ptman/logic/parser/UnapplyCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.ptman.logic.parser;
+
+import static seedu.ptman.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.ptman.logic.parser.CliSyntax.PREFIX_PASSWORD;
+
+import java.util.Optional;
+
+import seedu.ptman.commons.core.index.Index;
+import seedu.ptman.commons.exceptions.IllegalValueException;
+import seedu.ptman.logic.commands.UnapplyCommand;
+import seedu.ptman.logic.parser.exceptions.ParseException;
+import seedu.ptman.model.Password;
+
+/**
+ * Parses input arguments and creates a new ApplyCommand object
+ */
+public class UnapplyCommandParser implements Parser<UnapplyCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ApplyCommand
+     * and returns an ApplyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnapplyCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PASSWORD);
+        try {
+            Optional<Password> password = ParserUtil.parsePassword(argMultimap.getValue(PREFIX_PASSWORD));
+            Index employeeIndex = ParserUtil.parseFirstIndex(clearPasswordFromCommand(args));
+            Index shiftIndex = ParserUtil.parseSecondIndex(clearPasswordFromCommand(args));
+            return new UnapplyCommand(employeeIndex, shiftIndex, password);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnapplyCommand.MESSAGE_USAGE));
+        }
+    }
+
+    /**
+     * cut away password at the end of the command
+     */
+    private String clearPasswordFromCommand(String args) {
+        int startIndex = args.indexOf(PREFIX_PASSWORD.getPrefix());
+        if (startIndex == -1) {
+            return args;
+        } else {
+            return args.substring(0, startIndex);
+        }
+    }
+}

--- a/src/main/java/seedu/ptman/model/outlet/Shift.java
+++ b/src/main/java/seedu/ptman/model/outlet/Shift.java
@@ -61,7 +61,7 @@ public class Shift {
      * @param employee
      * @throws EmployeeNotFoundException
      */
-    protected void removeEmployee(Employee employee) throws EmployeeNotFoundException {
+    public void removeEmployee(Employee employee) throws EmployeeNotFoundException {
         uniqueEmployeeList.remove(employee);
     }
 

--- a/src/test/java/seedu/ptman/logic/commands/ApplyCommandTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/ApplyCommandTest.java
@@ -33,7 +33,7 @@ import seedu.ptman.testutil.Assert;
 import seedu.ptman.testutil.EmployeeBuilder;
 
 /**
- * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for ApplyCommand.
  */
 public class ApplyCommandTest {
     @Rule

--- a/src/test/java/seedu/ptman/logic/commands/DeleteShiftCommandTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/DeleteShiftCommandTest.java
@@ -28,7 +28,7 @@ import seedu.ptman.model.outlet.Shift;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
- * {@code DeleteCommand}.
+ * {@code DeleteShiftCommand}.
  */
 public class DeleteShiftCommandTest {
 

--- a/src/test/java/seedu/ptman/logic/commands/UnapplyCommandTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/UnapplyCommandTest.java
@@ -1,0 +1,256 @@
+package seedu.ptman.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.ptman.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.ptman.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.ptman.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
+import static seedu.ptman.testutil.TypicalIndexes.INDEX_FIRST_SHIFT;
+import static seedu.ptman.testutil.TypicalIndexes.INDEX_SECOND_EMPLOYEE;
+import static seedu.ptman.testutil.TypicalIndexes.INDEX_SECOND_SHIFT;
+import static seedu.ptman.testutil.TypicalShifts.getTypicalPartTimeManagerWithShifts;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.ptman.commons.core.index.Index;
+import seedu.ptman.logic.CommandHistory;
+import seedu.ptman.logic.UndoRedoStack;
+import seedu.ptman.logic.commands.exceptions.CommandException;
+import seedu.ptman.logic.commands.exceptions.MissingPasswordException;
+import seedu.ptman.model.Model;
+import seedu.ptman.model.ModelManager;
+import seedu.ptman.model.PartTimeManager;
+import seedu.ptman.model.Password;
+import seedu.ptman.model.UserPrefs;
+import seedu.ptman.model.employee.Employee;
+import seedu.ptman.model.employee.exceptions.InvalidPasswordException;
+import seedu.ptman.model.outlet.OutletInformation;
+import seedu.ptman.model.outlet.Shift;
+import seedu.ptman.testutil.Assert;
+import seedu.ptman.testutil.EmployeeBuilder;
+import seedu.ptman.testutil.ShiftBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand)
+ * and unit tests for UnapplyCommand.
+ */
+public class UnapplyCommandTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Model model = new ModelManager(new PartTimeManager(getTypicalPartTimeManagerWithShifts()), new UserPrefs(),
+            new OutletInformation());
+
+    @Before
+    public void setMode_adminMode() {
+        model.setTrueAdminMode(new Password());
+    }
+
+    @Test
+    public void execute_employeeNotInShift_throwsCommandException() throws Exception {
+        Model model = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        model.setTrueAdminMode(new Password());
+        Employee employee = new EmployeeBuilder().withName("Absent").build();
+        Shift shift = new ShiftBuilder().build();
+        model.addEmployee(employee);
+        model.addShift(shift);
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+
+        assertCommandFailure(unapplyCommand, model, UnapplyCommand.MESSAGE_EMPLOYEE_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_adminModeEmployeeInShift_success() throws Exception {
+        Model model = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        Model expectedModel = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        model.setTrueAdminMode(new Password());
+        expectedModel.setTrueAdminMode(new Password());
+        Employee employee = new EmployeeBuilder().withName("Present").build();
+        Employee expectedEmployee = new EmployeeBuilder().withName("Present").build();
+        Shift shift = new ShiftBuilder().build();
+        Shift expectedShift = new ShiftBuilder().build();
+        shift.addEmployee(employee);
+        model.addEmployee(employee);
+        model.addShift(shift);
+        expectedModel.addShift(expectedShift);
+        expectedModel.addEmployee(expectedEmployee);
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+
+        String expectedMessage =
+                String.format(UnapplyCommand.MESSAGE_UNAPPLY_SHIFT_SUCCESS, expectedEmployee.getName(), 1);
+
+        assertCommandSuccess(unapplyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_userModeEmployeeInShift_success() throws Exception {
+        Model model = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        Model expectedModel = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        model.setFalseAdminMode();
+        expectedModel.setFalseAdminMode();
+        Employee employee = new EmployeeBuilder().withName("Present").build();
+        Employee expectedEmployee = new EmployeeBuilder().withName("Present").build();
+        Shift shift = new ShiftBuilder().build();
+        Shift expectedShift = new ShiftBuilder().build();
+        shift.addEmployee(employee);
+        model.addEmployee(employee);
+        model.addShift(shift);
+        expectedModel.addShift(expectedShift);
+        expectedModel.addEmployee(expectedEmployee);
+        UnapplyCommand unapplyCommand = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+
+        String expectedMessage =
+                String.format(UnapplyCommand.MESSAGE_UNAPPLY_SHIFT_SUCCESS, expectedEmployee.getName(), 1);
+
+        assertCommandSuccess(unapplyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_userModeNoPassword_throwsMissingPasswordException() throws Exception {
+        Model model = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        model.setFalseAdminMode();
+        Employee employee = new EmployeeBuilder().withName("Present").build();
+        Shift shift = new ShiftBuilder().build();
+        shift.addEmployee(employee);
+        model.addEmployee(employee);
+        model.addShift(shift);
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+
+        Assert.assertThrows(MissingPasswordException.class, unapplyCommand::execute);
+    }
+
+    @Test
+    public void execute_userModeIncorrectPassword_throwsInvalidPasswordException() throws Exception {
+        Model model = new ModelManager(new PartTimeManager(), new UserPrefs(), new OutletInformation());
+        model.setFalseAdminMode();
+        Employee employee = new EmployeeBuilder().withName("Present").withPassword("incorrect").build();
+        Shift shift = new ShiftBuilder().build();
+        shift.addEmployee(employee);
+        model.addEmployee(employee);
+        model.addShift(shift);
+        UnapplyCommand unapplyCommand = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+
+        Assert.assertThrows(InvalidPasswordException.class, unapplyCommand::execute);
+    }
+
+    @Test
+    public void equals_sameObject_returnsTrue() {
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertTrue(unapplyCommand.equals(unapplyCommand));
+        assertTrue(unapplyCommandPw.equals(unapplyCommandPw));
+    }
+
+    @Test
+    public void equals_sameValues_returnsTrue() {
+        UnapplyCommand unapplyCommand1 = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommand2 = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw1 = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw2 = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertTrue(unapplyCommand1.equals(unapplyCommand2));
+        assertTrue(unapplyCommandPw1.equals(unapplyCommandPw2));
+    }
+
+    @Test
+    public void equals_differentTypes_returnsFalse() {
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertFalse(unapplyCommand.equals(1));
+        assertFalse(unapplyCommandPw.equals(1));
+    }
+
+    @Test
+    public void equals_null_returnsFalse() {
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw = prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertFalse(unapplyCommand.equals(null));
+        assertFalse(unapplyCommandPw.equals(null));
+    }
+
+    @Test
+    public void equals_differentShifts_returnsFalse() {
+        UnapplyCommand unapplyCommandFirst =
+                prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandSecond =
+                prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_SHIFT, model);
+        UnapplyCommand unapplyCommandPwFirst =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPwSecond =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_SECOND_SHIFT, model);
+        assertFalse(unapplyCommandFirst.equals(unapplyCommandSecond));
+        assertFalse(unapplyCommandPwFirst.equals(unapplyCommandPwSecond));
+    }
+
+    @Test
+    public void equals_differentEmployees_returnsFalse() {
+        UnapplyCommand unapplyCommandFirst =
+                prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandSecond =
+                prepareCommandWithoutPassword(INDEX_SECOND_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPwFirst =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPwSecond =
+                prepareCommandWithPassword(INDEX_SECOND_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertFalse(unapplyCommandFirst.equals(unapplyCommandSecond));
+        assertFalse(unapplyCommandPwFirst.equals(unapplyCommandPwSecond));
+    }
+
+    @Test
+    public void execute_shiftIndexOutOfRange_throwsCommandException() {
+        UnapplyCommand unapplyCommand =
+                prepareCommandWithoutPassword(INDEX_FIRST_EMPLOYEE, Index.fromOneBased(99), model);
+        UnapplyCommand unapplyCommandPw =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, Index.fromOneBased(99), model);
+        Assert.assertThrows(CommandException.class, unapplyCommand::execute);
+        Assert.assertThrows(CommandException.class, unapplyCommandPw::execute);
+    }
+
+    @Test
+    public void execute_employeeIndexOutOfRange_throwsCommandException() {
+        UnapplyCommand unapplyCommand = prepareCommandWithoutPassword(Index.fromOneBased(99), INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommandPw = prepareCommandWithPassword(Index.fromOneBased(99), INDEX_FIRST_SHIFT, model);
+        Assert.assertThrows(CommandException.class, unapplyCommand::execute);
+        Assert.assertThrows(CommandException.class, unapplyCommandPw::execute);
+    }
+
+    @Test
+    public void execute_incorrectPassword_throwsInvalidPasswordException() {
+        ApplyCommand applyCommand = new ApplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT,
+                new Password("wrongPassword"));
+        applyCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        Assert.assertThrows(InvalidPasswordException.class, applyCommand::execute);
+    }
+
+    @Test
+    public void hashCode_sameValues_returnsSameHashCode() {
+        UnapplyCommand unapplyCommand1 =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        UnapplyCommand unapplyCommand2 =
+                prepareCommandWithPassword(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, model);
+        assertEquals(unapplyCommand1.hashCode(), unapplyCommand2.hashCode());
+    }
+
+    /**
+     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}
+     */
+    private UnapplyCommand prepareCommandWithPassword(Index employeeIndex, Index shiftIndex, Model model) {
+        UnapplyCommand unapplyCommand = new UnapplyCommand(employeeIndex, shiftIndex, Optional.of(new Password()));
+        unapplyCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return unapplyCommand;
+    }
+
+    /**
+     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}
+     */
+    private UnapplyCommand prepareCommandWithoutPassword(Index employeeIndex, Index shiftIndex, Model model) {
+        UnapplyCommand unapplyCommand = new UnapplyCommand(employeeIndex, shiftIndex, Optional.empty());
+        unapplyCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return unapplyCommand;
+    }
+}

--- a/src/test/java/seedu/ptman/logic/parser/DeleteShiftCommandParserTest.java
+++ b/src/test/java/seedu/ptman/logic/parser/DeleteShiftCommandParserTest.java
@@ -11,8 +11,8 @@ import seedu.ptman.logic.commands.DeleteShiftCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
+ * outside of the DeleteShiftCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteShiftCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */

--- a/src/test/java/seedu/ptman/logic/parser/PartTimeManagerParserTest.java
+++ b/src/test/java/seedu/ptman/logic/parser/PartTimeManagerParserTest.java
@@ -15,6 +15,7 @@ import static seedu.ptman.testutil.TypicalIndexes.INDEX_FIRST_SHIFT;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Rule;
@@ -39,6 +40,7 @@ import seedu.ptman.logic.commands.ListCommand;
 import seedu.ptman.logic.commands.LogOutAdminCommand;
 import seedu.ptman.logic.commands.RedoCommand;
 import seedu.ptman.logic.commands.SelectCommand;
+import seedu.ptman.logic.commands.UnapplyCommand;
 import seedu.ptman.logic.commands.UndoCommand;
 import seedu.ptman.logic.parser.exceptions.ParseException;
 import seedu.ptman.model.Password;
@@ -122,6 +124,22 @@ public class PartTimeManagerParserTest {
                 ApplyCommand.COMMAND_ALIAS + " " + INDEX_FIRST_EMPLOYEE.getOneBased()
                         + " " + INDEX_FIRST_SHIFT.getOneBased() + " " + PREFIX_PASSWORD + "DEFAULT1");
         assertEquals(new ApplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, new Password()), command);
+    }
+
+    @Test
+    public void parseCommand_unapply() throws Exception {
+        UnapplyCommand command = (UnapplyCommand) parser.parseCommand(
+                UnapplyCommand.COMMAND_WORD + " " + INDEX_FIRST_EMPLOYEE.getOneBased()
+                        + " " + INDEX_FIRST_SHIFT.getOneBased() + " " + PREFIX_PASSWORD + "DEFAULT1");
+        assertEquals(new UnapplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, Optional.of(new Password())), command);
+    }
+
+    @Test
+    public void parseCommand_unapplyAlias() throws Exception {
+        UnapplyCommand command = (UnapplyCommand) parser.parseCommand(
+                UnapplyCommand.COMMAND_ALIAS + " " + INDEX_FIRST_EMPLOYEE.getOneBased()
+                        + " " + INDEX_FIRST_SHIFT.getOneBased() + " " + PREFIX_PASSWORD + "DEFAULT1");
+        assertEquals(new UnapplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, Optional.of(new Password())), command);
     }
 
     @Test

--- a/src/test/java/seedu/ptman/logic/parser/UnapplyCommandParserTest.java
+++ b/src/test/java/seedu/ptman/logic/parser/UnapplyCommandParserTest.java
@@ -6,36 +6,39 @@ import static seedu.ptman.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.ptman.testutil.TypicalIndexes.INDEX_FIRST_EMPLOYEE;
 import static seedu.ptman.testutil.TypicalIndexes.INDEX_FIRST_SHIFT;
 
+import java.util.Optional;
+
 import org.junit.Test;
 
-import seedu.ptman.logic.commands.ApplyCommand;
+import seedu.ptman.logic.commands.UnapplyCommand;
 import seedu.ptman.model.Password;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the ApplyCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the ApplyCommand, and therefore we test only one of them.
+ * outside of the UnapplyCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the UnapplyCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */
-public class ApplyCommandParserTest {
+public class UnapplyCommandParserTest {
 
-    private ApplyCommandParser parser = new ApplyCommandParser();
+    private UnapplyCommandParser parser = new UnapplyCommandParser();
 
     @Test
-    public void parse_validArgs_returnsApplyCommand() {
+    public void parse_userModeValidArgs_returnsApplyCommand() {
         assertParseSuccess(parser, "1 1 pw/DEFAULT1",
-                new ApplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, new Password()));
+                new UnapplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, Optional.of(new Password())));
     }
 
     @Test
-    public void parse_noPassword_throwsParseException() {
-        assertParseFailure(parser, "1 1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ApplyCommand.MESSAGE_USAGE));
+    public void parse_adminModeValidArgs_returnsApplyCommand() {
+        assertParseSuccess(parser, "1 1",
+                new UnapplyCommand(INDEX_FIRST_EMPLOYEE, INDEX_FIRST_SHIFT, Optional.empty()));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a b pw/DEFAULT1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ApplyCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnapplyCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Format: `unapply EMPLOYEE_INDEX SHIFT_INDEX [pw/PASSWORD]`
Alias: `uap`

The password field for the employee password. It is not required if PTMan is in admin mode.

Closes #92, #106, #107