### PR TITLE
Polish the Shifts feature

### DIFF
--- a/src/main/java/seedu/ptman/logic/commands/AddShiftCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/AddShiftCommand.java
@@ -7,6 +7,8 @@ import static seedu.ptman.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.ptman.logic.parser.CliSyntax.PREFIX_TIME_END;
 import static seedu.ptman.logic.parser.CliSyntax.PREFIX_TIME_START;
 
+import java.time.LocalDate;
+
 import seedu.ptman.logic.commands.exceptions.CommandException;
 import seedu.ptman.model.shift.Shift;
 import seedu.ptman.model.shift.exceptions.DuplicateShiftException;
@@ -35,11 +37,12 @@ public class AddShiftCommand extends UndoableCommand {
 
     public static final String MESSAGE_SUCCESS = "New shift added: %1$s";
     public static final String MESSAGE_DUPLICATE_SHIFT = "This shift already exists in PTMan";
+    public static final String MESSAGE_DATE_OVER = "You cannot add a shift to a date that is already over";
 
     private final Shift toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Shift}
+     * Creates an AddShiftCommand to add the specified {@code Shift}
      */
     public AddShiftCommand(Shift shift) {
         requireNonNull(shift);
@@ -54,13 +57,17 @@ public class AddShiftCommand extends UndoableCommand {
             throw new CommandException(MESSAGE_ACCESS_DENIED);
         }
 
+        LocalDate shiftDate = toAdd.getDate().getLocalDate();
+        if (shiftDate.isBefore(LocalDate.now())) {
+            throw new CommandException(MESSAGE_DATE_OVER);
+        }
+
         try {
             model.addShift(toAdd);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
         } catch (DuplicateShiftException e) {
             throw new CommandException(MESSAGE_DUPLICATE_SHIFT);
         }
-
     }
 
     @Override

--- a/src/main/java/seedu/ptman/logic/commands/ApplyCommand.java
+++ b/src/main/java/seedu/ptman/logic/commands/ApplyCommand.java
@@ -29,7 +29,7 @@ public class ApplyCommand extends UndoableCommand {
     public static final String COMMAND_WORD = "apply";
     public static final String COMMAND_ALIAS = "ap";
 
-    public static final String COMMAND_FORMAT = "EMPLOYEE_INDEX (must be a positive integer) "
+    public static final String COMMAND_FORMAT = "EMPLOYEE_INDEX "
             + "SHIFT_INDEX "
             + "[" + PREFIX_PASSWORD + "PASSWORD]";
     public static final String MESSAGE_USAGE = COMMAND_WORD

--- a/src/main/java/seedu/ptman/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/ptman/logic/parser/ParserUtil.java
@@ -39,7 +39,7 @@ import seedu.ptman.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_INSUFFICIENT_PARTS = "Number of parts must be more than 1.";
+    private static final int EXPECTED_MIN_ARG_LENGTH = 3;
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -75,6 +75,10 @@ public class ParserUtil {
      * @throws IllegalValueException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseSecondIndex(String oneBasedIndex) throws IllegalValueException {
+        String[] split = oneBasedIndex.trim().split(" ");
+        if (split.length < EXPECTED_MIN_ARG_LENGTH) {
+            throw new IllegalValueException(MESSAGE_INVALID_INDEX);
+        }
         String trimmedIndex = oneBasedIndex.trim().split(" ")[1];
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new IllegalValueException(MESSAGE_INVALID_INDEX);

--- a/src/main/java/seedu/ptman/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/ptman/logic/parser/ParserUtil.java
@@ -39,7 +39,7 @@ import seedu.ptman.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    private static final int EXPECTED_MIN_ARG_LENGTH = 3;
+    private static final int EXPECTED_MIN_ARG_LENGTH = 2;
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -79,7 +79,7 @@ public class ParserUtil {
         if (split.length < EXPECTED_MIN_ARG_LENGTH) {
             throw new IllegalValueException(MESSAGE_INVALID_INDEX);
         }
-        String trimmedIndex = oneBasedIndex.trim().split(" ")[1];
+        String trimmedIndex = split[1];
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new IllegalValueException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/ptman/model/shift/Date.java
+++ b/src/main/java/seedu/ptman/model/shift/Date.java
@@ -26,6 +26,11 @@ public class Date {
         this.date = LocalDate.parse(date, DateTimeFormatter.ofPattern(STRING_DATE_PATTERN));
     }
 
+    public Date(LocalDate date) {
+        requireNonNull(date);
+        this.date = date;
+    }
+
     /**
      * Returns true if a given string is a valid date.
      * @param test

--- a/src/main/java/seedu/ptman/model/shift/Shift.java
+++ b/src/main/java/seedu/ptman/model/shift/Shift.java
@@ -93,7 +93,6 @@ public class Shift {
         return startTime.equals(shift.startTime)
                 && endTime.equals(shift.endTime)
                 && date.equals(shift.date)
-                && uniqueEmployeeList.equals(shift.uniqueEmployeeList)
                 && capacity.equals(shift.capacity);
     }
 
@@ -135,10 +134,8 @@ public class Shift {
     public int compareTo(Shift other) {
         if (date.equals(other.getDate())) {
             return startTime.compareTo(other.getStartTime());
-        } else if (date.compareTo(other.getDate()) < 0) {
-            return -1;
         } else {
-            return 1;
+            return date.compareTo(other.getDate());
         }
     }
 

--- a/src/test/java/seedu/ptman/logic/commands/AddShiftCommandIntegrationTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/AddShiftCommandIntegrationTest.java
@@ -56,6 +56,12 @@ public class AddShiftCommandIntegrationTest {
         assertCommandFailure(prepareCommand(shift, model), model, AddShiftCommand.MESSAGE_DUPLICATE_SHIFT);
     }
 
+    @Test
+    public void execute_invalidShiftDate_throwsCommandException() {
+        Shift shift = new ShiftBuilder().withDate("01-01-10").build();
+        assertCommandFailure(prepareCommand(shift, model), model, AddShiftCommand.MESSAGE_DATE_OVER);
+    }
+
     /**
      * Generates a new {@code AddShiftCommand} which upon execution, adds {@code shift} into the {@code model}.
      */

--- a/src/test/java/seedu/ptman/logic/commands/AddShiftCommandIntegrationTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/AddShiftCommandIntegrationTest.java
@@ -4,6 +4,8 @@ import static seedu.ptman.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.ptman.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.ptman.testutil.TypicalShifts.getTypicalPartTimeManagerWithShifts;
 
+import java.time.LocalDate;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +17,7 @@ import seedu.ptman.model.Password;
 import seedu.ptman.model.UserPrefs;
 import seedu.ptman.model.outlet.OutletInformation;
 import seedu.ptman.model.shift.Shift;
+import seedu.ptman.model.shift.exceptions.DuplicateShiftException;
 import seedu.ptman.testutil.ShiftBuilder;
 
 //@@author shanwpf
@@ -28,14 +31,18 @@ public class AddShiftCommandIntegrationTest {
     @Before
     public void setUp() {
         model = new ModelManager(getTypicalPartTimeManagerWithShifts(), new UserPrefs(), new OutletInformation());
+        model.updateFilteredShiftList(Model.PREDICATE_SHOW_ALL_SHIFTS);
         model.setTrueAdminMode(new Password());
     }
 
     @Test
     public void execute_newShift_success() throws Exception {
-        Shift validShift = new ShiftBuilder().build();
+        Shift validShift = new ShiftBuilder().withDate(LocalDate.now()).build();
 
-        Model expectedModel = new ModelManager(model.getPartTimeManager(), new UserPrefs(), new OutletInformation());
+        Model expectedModel =
+                new ModelManager(getTypicalPartTimeManagerWithShifts(), new UserPrefs(), new OutletInformation());
+        expectedModel.setTrueAdminMode(new Password());
+        expectedModel.updateFilteredShiftList(Model.PREDICATE_SHOW_ALL_SHIFTS);
         expectedModel.addShift(validShift);
 
         assertCommandSuccess(prepareCommand(validShift, model), model,
@@ -43,13 +50,14 @@ public class AddShiftCommandIntegrationTest {
     }
 
     @Test
-    public void execute_duplicateShift_throwsCommandException() {
-        Shift shiftInList = model.getPartTimeManager().getShiftList().get(0);
-        assertCommandFailure(prepareCommand(shiftInList, model), model, AddShiftCommand.MESSAGE_DUPLICATE_SHIFT);
+    public void execute_duplicateShift_throwsCommandException() throws DuplicateShiftException {
+        Shift shift = new ShiftBuilder().withDate(LocalDate.now()).build();
+        model.addShift(shift);
+        assertCommandFailure(prepareCommand(shift, model), model, AddShiftCommand.MESSAGE_DUPLICATE_SHIFT);
     }
 
     /**
-     * Generates a new {@code AddCommand} which upon execution, adds {@code employee} into the {@code model}.
+     * Generates a new {@code AddShiftCommand} which upon execution, adds {@code shift} into the {@code model}.
      */
     private AddShiftCommand prepareCommand(Shift shift, Model model) {
         AddShiftCommand command = new AddShiftCommand(shift);

--- a/src/test/java/seedu/ptman/logic/commands/AddShiftCommandTest.java
+++ b/src/test/java/seedu/ptman/logic/commands/AddShiftCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 import static seedu.ptman.testutil.TypicalShifts.MONDAY_AM;
 import static seedu.ptman.testutil.TypicalShifts.MONDAY_PM;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
@@ -52,7 +53,7 @@ public class AddShiftCommandTest {
         ModelStubAcceptingShiftAdded modelStub = new ModelStubAcceptingShiftAdded();
         modelStub.setTrueAdminMode(new Password());
 
-        Shift validShift = new ShiftBuilder().build();
+        Shift validShift = new ShiftBuilder().withDate(LocalDate.now()).build();
         CommandResult commandResult = getAddShiftCommandForShift(validShift, modelStub).execute();
 
         assertEquals(String.format(AddShiftCommand.MESSAGE_SUCCESS, validShift), commandResult.feedbackToUser);
@@ -63,7 +64,7 @@ public class AddShiftCommandTest {
     public void execute_duplicateShift_throwsCommandException() throws Exception {
         ModelStub modelStub = new ModelStubThrowingDuplicateShiftException();
         modelStub.setTrueAdminMode(new Password());
-        Shift validShift = new ShiftBuilder().build();
+        Shift validShift = new ShiftBuilder().withDate(LocalDate.now()).build();
 
         thrown.expect(CommandException.class);
         thrown.expectMessage(AddShiftCommand.MESSAGE_DUPLICATE_SHIFT);

--- a/src/test/java/seedu/ptman/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/ptman/logic/commands/CommandTestUtil.java
@@ -33,6 +33,7 @@ import seedu.ptman.model.PartTimeManager;
 import seedu.ptman.model.employee.Employee;
 import seedu.ptman.model.employee.NameContainsKeywordsPredicate;
 import seedu.ptman.model.employee.exceptions.EmployeeNotFoundException;
+import seedu.ptman.model.shift.Shift;
 import seedu.ptman.testutil.EditEmployeeDescriptorBuilder;
 
 /**
@@ -157,6 +158,7 @@ public class CommandTestUtil {
         // only do so by copying its components.
         PartTimeManager expectedPartTimeManager = new PartTimeManager(actualModel.getPartTimeManager());
         List<Employee> expectedFilteredList = new ArrayList<>(actualModel.getFilteredEmployeeList());
+        List<Shift> expectedFilteredShiftList = new ArrayList<>(actualModel.getFilteredShiftList());
 
         try {
             command.execute();
@@ -165,6 +167,7 @@ public class CommandTestUtil {
             assertEquals(expectedMessage, e.getMessage());
             assertEquals(expectedPartTimeManager, actualModel.getPartTimeManager());
             assertEquals(expectedFilteredList, actualModel.getFilteredEmployeeList());
+            assertEquals(expectedFilteredShiftList, actualModel.getFilteredShiftList());
         }
     }
 

--- a/src/test/java/seedu/ptman/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/ptman/logic/parser/ParserUtilTest.java
@@ -71,6 +71,13 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseSecondIndex_insufficientArgs_throwsIllegalValueException() throws IllegalValueException {
+        thrown.expect(IllegalValueException.class);
+        thrown.expectMessage(MESSAGE_INVALID_INDEX);
+        ParserUtil.parseSecondIndex("1");
+    }
+
+    @Test
     public void parseIndex_validInput_success() throws Exception {
         // No whitespaces
         assertEquals(INDEX_FIRST_EMPLOYEE, ParserUtil.parseIndex("1"));

--- a/src/test/java/seedu/ptman/model/shift/DateTest.java
+++ b/src/test/java/seedu/ptman/model/shift/DateTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.time.LocalDate;
+
 import org.junit.Test;
 
 import seedu.ptman.testutil.Assert;
@@ -14,7 +16,8 @@ public class DateTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> new Date(null));
+        Assert.assertThrows(NullPointerException.class, () -> new Date((String) null));
+        Assert.assertThrows(NullPointerException.class, () -> new Date((LocalDate) null));
     }
 
     @Test

--- a/src/test/java/seedu/ptman/testutil/ShiftBuilder.java
+++ b/src/test/java/seedu/ptman/testutil/ShiftBuilder.java
@@ -1,5 +1,6 @@
 package seedu.ptman.testutil;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -39,6 +40,14 @@ public class ShiftBuilder {
      * Sets the {@code Date} of the {@code Shift} that we are building.
      */
     public ShiftBuilder withDate(String date) {
+        this.date = new Date(date);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Date} of the {@code Shift} that we are building.
+     */
+    public ShiftBuilder withDate(LocalDate date) {
         this.date = new Date(date);
         return this;
     }


### PR DESCRIPTION
Fixes #189
Shifts with dates before the current date can no longer be added.

Fixes #203 
Check for arguments when parsing.

Fixes #202 
Do not consider employees when checking shift equality.